### PR TITLE
Pass FileFormatOptions through to DataFusion scan for update and delete

### DIFF
--- a/crates/core/src/delta_datafusion/mod.rs
+++ b/crates/core/src/delta_datafusion/mod.rs
@@ -89,6 +89,7 @@ pub mod planner;
 mod schema_adapter;
 mod table_provider;
 
+use crate::table::file_format_options::{to_table_parquet_options_from_ffo, FileFormatRef};
 pub use cdf::scan::DeltaCdfTableProvider;
 pub(crate) use table_provider::DeltaScanBuilder;
 pub use table_provider::{DeltaScan, DeltaScanConfig, DeltaScanConfigBuilder, DeltaTableProvider};
@@ -938,6 +939,7 @@ pub(crate) async fn find_files_scan(
     snapshot: &DeltaTableState,
     log_store: LogStoreRef,
     state: &SessionState,
+    file_format_options: Option<&FileFormatRef>,
     expression: Expr,
 ) -> DeltaResult<Vec<Add>> {
     let candidate_map: HashMap<String, Add> = snapshot
@@ -963,10 +965,13 @@ pub(crate) async fn find_files_scan(
     // Add path column
     used_columns.push(logical_schema.index_of(scan_config.file_column_name.as_ref().unwrap())?);
 
+    let table_parquet_options = to_table_parquet_options_from_ffo(file_format_options);
+
     let scan = DeltaScanBuilder::new(snapshot, log_store, state)
         .with_filter(Some(expression.clone()))
         .with_projection(Some(&used_columns))
         .with_scan_config(scan_config)
+        .with_parquet_options(table_parquet_options)
         .build()
         .await?;
     let scan = Arc::new(scan);
@@ -1053,6 +1058,7 @@ pub async fn find_files(
     snapshot: &DeltaTableState,
     log_store: LogStoreRef,
     state: &SessionState,
+    file_format_options: Option<&FileFormatRef>,
     predicate: Option<Expr>,
 ) -> DeltaResult<FindFiles> {
     let current_metadata = snapshot.metadata();
@@ -1076,8 +1082,14 @@ pub async fn find_files(
                     partition_scan: true,
                 })
             } else {
-                let candidates =
-                    find_files_scan(snapshot, log_store, state, predicate.to_owned()).await?;
+                let candidates = find_files_scan(
+                    snapshot,
+                    log_store,
+                    state,
+                    file_format_options,
+                    predicate.to_owned(),
+                )
+                .await?;
 
                 Ok(FindFiles {
                     candidates,

--- a/crates/core/src/operations/delete.rs
+++ b/crates/core/src/operations/delete.rs
@@ -345,7 +345,14 @@ async fn execute(
     let mut metrics = DeleteMetrics::default();
 
     let scan_start = Instant::now();
-    let candidates = find_files(&snapshot, log_store.clone(), &state, predicate.clone()).await?;
+    let candidates = find_files(
+        &snapshot,
+        log_store.clone(),
+        &state,
+        file_format_options.as_ref(),
+        predicate.clone(),
+    )
+    .await?;
     metrics.scan_time_ms = Instant::now().duration_since(scan_start).as_millis() as u64;
 
     let predicate = predicate.unwrap_or(lit(true));

--- a/crates/core/src/operations/update.rs
+++ b/crates/core/src/operations/update.rs
@@ -324,7 +324,14 @@ async fn execute(
     let table_partition_cols = current_metadata.partition_columns().clone();
 
     let scan_start = Instant::now();
-    let candidates = find_files(&snapshot, log_store.clone(), &state, predicate.clone()).await?;
+    let candidates = find_files(
+        &snapshot,
+        log_store.clone(),
+        &state,
+        file_format_options.as_ref(),
+        predicate.clone(),
+    )
+    .await?;
     metrics.scan_time_ms = Instant::now().duration_since(scan_start).as_millis() as u64;
 
     if candidates.candidates.is_empty() {

--- a/crates/core/src/operations/write/mod.rs
+++ b/crates/core/src/operations/write/mod.rs
@@ -667,6 +667,7 @@ impl std::future::IntoFuture for WriteBuilder {
                                 snapshot,
                                 state.clone(),
                                 partition_columns.clone(),
+                                this.file_format_options.as_ref(),
                                 this.writer_properties_factory.clone(),
                                 deletion_timestamp,
                                 writer_stats_config.clone(),

--- a/crates/core/src/table/file_format_options.rs
+++ b/crates/core/src/table/file_format_options.rs
@@ -88,26 +88,7 @@ pub fn state_with_file_format_options(
     if let Some(ffo) = file_format_options {
         ffo.update_session(&state)?;
     }
-    // Convert file format options to parquet options and delegate to the common implementation
-    let parquet_options = to_table_parquet_options_from_ffo(file_format_options);
-    Ok(state_with_parquet_options(state, parquet_options.as_ref()))
-}
-
-#[cfg(feature = "datafusion")]
-pub fn state_with_parquet_options(
-    state: SessionState,
-    parquet_options: Option<&TableParquetOptions>,
-) -> SessionState {
-    if let Some(parquet) = parquet_options {
-        let mut sb = SessionStateBuilder::new_from_existing(state.clone());
-        let mut tbl_opts = TableOptions::new();
-        tbl_opts.parquet = parquet.clone();
-        tbl_opts.set_config_format(ConfigFileType::PARQUET);
-        sb = sb.with_table_options(tbl_opts);
-        let state = sb.build();
-        return state;
-    }
-    state
+    Ok(state)
 }
 
 #[cfg(feature = "datafusion")]


### PR DESCRIPTION
This avoids needing to set the table options on the DataFusion session state.