### PR TITLE
refactor(optimize): use DataFusion scan for compact reads instead of raw ParquetObjectReader

### DIFF
--- a/crates/core/src/delta_datafusion/mod.rs
+++ b/crates/core/src/delta_datafusion/mod.rs
@@ -64,6 +64,7 @@ pub use self::session::{
     DeltaParserOptions, DeltaRuntimeEnvBuilder, DeltaSessionConfig, DeltaSessionContext,
     create_session, create_session_state_with_spill_config,
 };
+pub(crate) use self::table_provider::next::FileSelection;
 pub use self::table_provider::next::{DeletionVectorSelection, DeltaScan as DeltaScanNext};
 pub(crate) use self::utils::*;
 pub use cdf::scan::DeltaCdfTableProvider;

--- a/crates/core/src/operations/optimize.rs
+++ b/crates/core/src/operations/optimize.rs
@@ -39,7 +39,6 @@ use futures::{Future, StreamExt, TryStreamExt};
 use indexmap::IndexMap;
 use itertools::Itertools;
 use num_cpus;
-use parquet::arrow::async_reader::{ParquetObjectReader, ParquetRecordBatchStreamBuilder};
 use parquet::basic::{Compression, ZstdLevel};
 use parquet::errors::ParquetError;
 use parquet::file::properties::WriterProperties;
@@ -655,13 +654,16 @@ impl MergePlan {
         let operations = std::mem::take(&mut self.operations);
         info!("starting optimize execution");
         let object_store = log_store.object_store(Some(operation_id));
+        let compact_task_parameters = self.task_parameters.clone();
+        let log_store_for_compact = log_store.clone();
+        let compact_table_root = snapshot.table_configuration().table_root().clone();
 
         let stream = match operations {
             OptimizeOperations::Compact(bins) => futures::stream::iter(bins)
                 .flat_map(|(_, (partition, bins))| {
                     futures::stream::iter(bins).map(move |bin| (partition.clone(), bin))
                 })
-                .map(|(partition, files)| {
+                .map(move |(partition, files)| {
                     debug!(
                         "merging a group of {} files in partition {partition:?}",
                         files.len(),
@@ -669,29 +671,51 @@ impl MergePlan {
                     for file in files.iter() {
                         debug!("  file {}", file.path);
                     }
-                    let object_store_ref = object_store.clone();
-                    let batch_stream = futures::stream::iter(files.clone())
-                        .then(move |file| {
-                            let object_store_ref = object_store_ref.clone();
-                            let meta = ObjectMeta::try_from(file).unwrap();
-                            async move {
-                                let file_reader =
-                                    ParquetObjectReader::new(object_store_ref, meta.location)
-                                        .with_file_size(meta.size);
-                                ParquetRecordBatchStreamBuilder::new(file_reader)
-                                    .await?
-                                    .build()
-                            }
+                    let batch_stream: BoxFuture<
+                        'static,
+                        Result<ParquetReadStream, DeltaTableError>,
+                    > = {
+                        use crate::delta_datafusion::{
+                            DeltaScanConfigBuilder, DeltaScanNext, FileSelection,
+                        };
+                        use datafusion::execution::context::SessionContext;
+                        let snapshot_for_stream = snapshot.clone();
+                        let files_clone = files.clone();
+                        let log_store_clone = log_store_for_compact.clone();
+                        let table_root_clone = compact_table_root.clone();
+                        Box::pin(async move {
+                            let ctx = Arc::new(SessionContext::new());
+                            let scan_config = DeltaScanConfigBuilder::default()
+                                .with_file_column(false)
+                                .build(&snapshot_for_stream)?;
+                            let selection = FileSelection::from_adds(
+                                files_clone.files.iter().cloned(),
+                                &table_root_clone,
+                            )?;
+                            let provider = Arc::new(
+                                DeltaScanNext::new(snapshot_for_stream, scan_config)?
+                                    .with_log_store(log_store_clone)
+                                    .with_file_selection(selection),
+                            )
+                                as Arc<dyn datafusion::catalog::TableProvider>;
+                            let stream = ctx
+                                .read_table(provider)?
+                                .execute_stream()
+                                .await?
+                                .map_err(|e| {
+                                    ParquetError::General(format!("Compact scan failed: {e}"))
+                                })
+                                .boxed();
+                            Ok(stream)
                         })
-                        .try_flatten()
-                        .boxed();
+                    };
 
                     let rewrite_result = tokio::task::spawn(Self::rewrite_files(
-                        self.task_parameters.clone(),
+                        compact_task_parameters.clone(),
                         partition,
                         files,
                         object_store.clone(),
-                        futures::future::ready(Ok(batch_stream)),
+                        batch_stream,
                         true,
                     ));
                     util::flatten_join_error(rewrite_result)


### PR DESCRIPTION
## Summary

- The compact path in `OptimizeBuilder` previously used `ParquetObjectReader` + `ParquetRecordBatchStreamBuilder` directly, bypassing DataFusion entirely
- Replaced with `DeltaScanNext` + a transient `SessionContext`, matching the pattern already used by the z-order path
- Removes the raw parquet reader dependency from the optimize hot path — DataFusion's scan handles file access, projection, and schema evolution uniformly across both compact and z-order

**Why this matters:** the raw reader cannot participate in DataFusion session-level features (encryption factories, custom object stores, pushdown). Routing all reads through `DeltaScanNext` ensures those features apply consistently, and is a prerequisite for the encryption PR that follows.

## Test plan

- [x] All 16 existing `command_optimize` tests pass unchanged
- [x] z-order tests (`test_zorder_*`) unaffected
- [x] Compact produces identical row counts and data values before/after

🤖 Generated with [Claude Code](https://claude.com/claude-code)